### PR TITLE
feat: 도메인 엔티티 및 공통 응답/예외 처리 구조 구현

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/entity/Menu.java
@@ -1,0 +1,32 @@
+package com.example.coffeeordersystem.domain.menu.entity;
+
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "menus")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Menu extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    public static Menu create(String name, BigDecimal price) {
+        return Menu.builder()
+                .name(name)
+                .price(price)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.coffeeordersystem.domain.menu.repository;
+
+import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
@@ -1,0 +1,46 @@
+package com.example.coffeeordersystem.domain.order.entity;
+
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private BigDecimal totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    private LocalDateTime orderedAt;
+
+    public static Order create(User user, BigDecimal totalPrice) {
+        return Order.builder()
+                .user(user)
+                .totalPrice(totalPrice)
+                .status(OrderStatus.WAITING)
+                .orderedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void complete() {
+        this.status = OrderStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderItem.java
@@ -1,0 +1,40 @@
+package com.example.coffeeordersystem.domain.order.entity;
+
+import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "order_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    private String name;
+    private BigDecimal price;
+
+    public static OrderItem create(Order order, Menu menu) {
+        return OrderItem.builder()
+                .order(order)
+                .menu(menu)
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderStatus.java
@@ -1,0 +1,16 @@
+package com.example.coffeeordersystem.domain.order.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+    WAITING("주문 확인"),
+    PREPARING("조리 중"),
+    COMPLETED( "조리 완료");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package com.example.coffeeordersystem.domain.order.repository;
+
+import com.example.coffeeordersystem.domain.order.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    List<OrderItem> findAllByOrderId(Long orderId);
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.example.coffeeordersystem.domain.order.repository;
+
+import com.example.coffeeordersystem.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/payment/entity/Payment.java
@@ -1,0 +1,58 @@
+package com.example.coffeeordersystem.domain.payment.entity;
+
+import com.example.coffeeordersystem.domain.order.entity.Order;
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Payment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+
+    private LocalDateTime paidAt;
+
+    public static Payment success(Order order, User user, BigDecimal amount) {
+        return Payment.builder()
+                .order(order)
+                .user(user)
+                .amount(amount)
+                .status(PaymentStatus.SUCCESS)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Payment fail(Order order, User user, BigDecimal amount) {
+        return Payment.builder()
+                .order(order)
+                .user(user)
+                .amount(amount)
+                .status(PaymentStatus.FAILED)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,15 @@
+package com.example.coffeeordersystem.domain.payment.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentStatus {
+    SUCCESS("결제 성공"),
+    FAILED("결제 실패");
+
+    private final String description;
+
+    PaymentStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.example.coffeeordersystem.domain.payment.repository;
+
+import com.example.coffeeordersystem.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(Long orderId);
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/entity/PointHistory.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/entity/PointHistory.java
@@ -1,0 +1,46 @@
+package com.example.coffeeordersystem.domain.pointhistory.entity;
+
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "point_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PointHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    private PointHistoryStatus status;
+
+    public static PointHistory charge(User user, BigDecimal amount) {
+        return PointHistory.builder()
+                .user(user)
+                .amount(amount)
+                .status(PointHistoryStatus.CHARGE)
+                .build();
+    }
+
+    public static PointHistory use(User user, BigDecimal amount) {
+        return PointHistory.builder()
+                .user(user)
+                .amount(amount.negate())
+                .status(PointHistoryStatus.USE)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/entity/PointHistoryStatus.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/entity/PointHistoryStatus.java
@@ -1,0 +1,15 @@
+package com.example.coffeeordersystem.domain.pointhistory.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PointHistoryStatus {
+    CHARGE("포인트 충전"),
+    USE("포인트 사용");
+
+    private final String description;
+
+    PointHistoryStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/repository/PointHistoryRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/repository/PointHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.coffeeordersystem.domain.pointhistory.repository;
+
+import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+    List<PointHistory> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/entity/User.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/entity/User.java
@@ -1,0 +1,36 @@
+package com.example.coffeeordersystem.domain.user.entity;
+
+import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private BigDecimal point;
+
+    public static User create() {
+        return User.builder()
+                .point(BigDecimal.ZERO)
+                .build();
+    }
+
+    public void charge(BigDecimal amount) {
+        this.point = this.point.add(amount);
+    }
+
+    public void use(BigDecimal amount) {
+        this.point = this.point.subtract(amount);
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.coffeeordersystem.domain.user.repository;
+
+import com.example.coffeeordersystem.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/coffeeordersystem/global/common/dto/ApiResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/dto/ApiResponse.java
@@ -1,0 +1,41 @@
+package com.example.coffeeordersystem.global.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final int code;
+    private final T data;
+
+    public static <T> ApiResponse<T> ok() {
+        return new ApiResponse<>(true, 200, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, 200, data);
+    }
+
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(true, 201, data);
+    }
+
+    public static <T> ApiResponse<T> noContent() {
+        return new ApiResponse<>(true, 204, null);
+    }
+
+    public static <T> ApiResponse<T> fail(HttpStatus status) {
+        return new ApiResponse<>(false, status.value(), null);
+    }
+
+    public static <T> ApiResponse<T> fail(HttpStatus status, T data) {
+        return new ApiResponse<>(false, status.value(), data);
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/global/common/dto/ExceptionResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/dto/ExceptionResponse.java
@@ -1,0 +1,25 @@
+package com.example.coffeeordersystem.global.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExceptionResponse {
+
+    private final int errorCode;
+    private final String message;
+    private final String path;
+    private final LocalDateTime time;
+
+    public static ExceptionResponse from(int errorCode, String message, String path) {
+        return ExceptionResponse.builder()
+                .errorCode(errorCode)
+                .message(message)
+                .path(path)
+                .time(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.example.coffeeordersystem.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/coffeeordersystem/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.example.coffeeordersystem.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // MENU
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),
+
+    // ORDER
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+
+    // POINT
+    INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+    INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액이 올바르지 않습니다."),
+
+    // COMMON
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.example.coffeeordersystem.global.exception;
+
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import com.example.coffeeordersystem.global.common.dto.ExceptionResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ServiceException.class)
+    public ResponseEntity<ApiResponse<ExceptionResponse>> handleServiceException(ServiceException exception, HttpServletRequest request) {
+        ExceptionResponse response = ExceptionResponse.from(exception.getStatus().value(), exception.getMessage(), request.getRequestURI());
+        return ResponseEntity.status(exception.getStatus()).body(ApiResponse.fail(exception.getStatus(), response));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<ExceptionResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception, HttpServletRequest request) {
+        String errorMessage = exception.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("입력 값이 올바르지 않습니다.");
+
+        ExceptionResponse response = ExceptionResponse.from(exception.getStatusCode().value(), errorMessage, request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(HttpStatus.BAD_REQUEST, response));
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
@@ -1,0 +1,14 @@
+package com.example.coffeeordersystem.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ServiceException extends RuntimeException {
+    private final HttpStatus status;
+
+    public ServiceException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 도메인 엔티티 및 공통 응답/예외 처리 구조 구현

---

## ✨ 변경 사항
- 도메인 엔티티(User, Menu, Order, OrderItem, Payment, PointHistory) 구현
- 각 도메인별 Repository 인터페이스 생성
- BaseEntity 공통 필드(createdAt, modifiedAt) 구성
- ApiResponse / ExceptionResponse 공통 응답 구조 구현
- ErrorCode Enum 정의
- ServiceException 커스텀 예외 클래스 구현
- GlobalExceptionHandler 전역 예외 처리 구성

---

## 🔗 관련 이슈
- close #5 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [x] 엔티티 매핑 정상 동작 확인
- [ ] 예외 처리 구조 정상 동작 확인 (추후 검증 예정)

---

## 💡 참고 사항
- 프로젝트 초기 구조 설정 단계로, 이후 기능 개발에 맞춰 확장 예정입니다.
- 공통 응답 및 예외 처리 구조를 먼저 정의하여 API 응답의 일관성을 확보했습니다.
- 현재 컨트롤러 및 서비스 로직은 포함되지 않았으며, 이후 단계에서 구현 예정입니다.