### PR TITLE
refactor: 예외 처리 구조 개선 및 ErrorCode 기반 처리 적용

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     // ORDER
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
 
+    // PAYMENT
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
+
     // POINT
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액이 올바르지 않습니다."),

--- a/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.coffeeordersystem.global.exception;
 import com.example.coffeeordersystem.global.common.dto.ApiResponse;
 import com.example.coffeeordersystem.global.common.dto.ExceptionResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,22 +12,61 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ServiceException.class)
-    public ResponseEntity<ApiResponse<ExceptionResponse>> handleServiceException(ServiceException exception, HttpServletRequest request) {
-        ExceptionResponse response = ExceptionResponse.from(exception.getStatus().value(), exception.getMessage(), request.getRequestURI());
-        return ResponseEntity.status(exception.getStatus()).body(ApiResponse.fail(exception.getStatus(), response));
+    public ResponseEntity<ApiResponse<ExceptionResponse>> handleServiceException(
+            ServiceException exception,
+            HttpServletRequest request) {
+
+        ExceptionResponse response = ExceptionResponse.from(
+                exception.getStatus().value(),
+                exception.getErrorCode().getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(ApiResponse.fail(exception.getStatus(), response));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<ExceptionResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<ExceptionResponse>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception,
+            HttpServletRequest request
+    ) {
         String errorMessage = exception.getBindingResult().getFieldErrors().stream()
                 .findFirst()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("입력 값이 올바르지 않습니다.");
 
-        ExceptionResponse response = ExceptionResponse.from(exception.getStatusCode().value(), errorMessage, request.getRequestURI());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(HttpStatus.BAD_REQUEST, response));
+        ExceptionResponse response = ExceptionResponse.from(
+                exception.getStatusCode().value(),
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST, response));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ExceptionResponse>> handleException(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        log.error("Unhandled exception occurred", exception);
+
+        ExceptionResponse response = ExceptionResponse.from(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR, response));
     }
 }

--- a/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
@@ -5,10 +5,15 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public class ServiceException extends RuntimeException {
-    private final HttpStatus status;
 
-    public ServiceException(HttpStatus status, String message) {
-        super(message);
-        this.status = status;
+    private final ErrorCode errorCode;
+
+    public ServiceException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
refactor: 예외 처리 구조 개선 및 ErrorCode 기반 처리 적용

---

## ✨ 변경 사항
- ServiceException을 ErrorCode 기반 구조로 리팩토링  
- ErrorCode에 Payment 관련 예외 추가  
- GlobalExceptionHandler에서 ErrorCode 기반 처리 적용  
- Exception.class 핸들러 추가 (예외 fallback 처리)  
- @Slf4j 적용 및 예외 로그 기록 추가  
- ApiResponse 형식으로 예외 응답 통일  

---

## 🔗 관련 이슈
- close #7 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [x] 예외 처리 정상 동작 확인  

---

## 💡 참고 사항
- 기존에는 일부 예외만 처리되어 예상하지 못한 예외 발생 시 응답 형식이 일관되지 않는 문제가 있었음  
- ErrorCode 중심 구조로 변경하여 상태 코드와 메시지 관리 책임을 명확히 분리  
- Exception 핸들러를 추가하여 예외 처리 범위를 확장  
- 모든 예외를 동일한 ApiResponse 형식으로 반환하도록 개선  