### PR TITLE
feat(user): 사용자 조회 및 포인트 충전 기능 구현

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package com.example.coffeeordersystem.domain.user.controller;
+
+import com.example.coffeeordersystem.domain.user.dto.request.UserChargeRequest;
+import com.example.coffeeordersystem.domain.user.dto.response.UserPointResponse;
+import com.example.coffeeordersystem.domain.user.dto.response.UserResponse;
+import com.example.coffeeordersystem.domain.user.service.UserService;
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 사용자 목록 조회
+    @GetMapping
+    public ApiResponse<List<UserResponse>> getUsers() {
+        return ApiResponse.ok(userService.getUsers());
+    }
+
+    // 사용자 단건 조회
+    @GetMapping("/{userId}")
+    public ApiResponse<UserResponse> getUser(@PathVariable Long userId) {
+        return ApiResponse.ok(userService.getUser(userId));
+    }
+
+    // 사용자 포인트 조회
+    @GetMapping("/{userId}/point")
+    public ApiResponse<UserPointResponse> getUserPoint(@PathVariable Long userId) {
+        return ApiResponse.ok(userService.getUserPoint(userId));
+    }
+
+    // 포인트 충전
+    @PostMapping("/{userId}/points/charge")
+    public ApiResponse<UserPointResponse> chargePoint(
+            @PathVariable Long userId,
+            @RequestBody UserChargeRequest request
+    ) {
+        return ApiResponse.ok(userService.chargePoint(userId, request));
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/dto/request/UserChargeRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/dto/request/UserChargeRequest.java
@@ -1,0 +1,11 @@
+package com.example.coffeeordersystem.domain.user.dto.request;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class UserChargeRequest {
+
+    private BigDecimal amount;
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/dto/response/UserPointResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/dto/response/UserPointResponse.java
@@ -1,0 +1,22 @@
+package com.example.coffeeordersystem.domain.user.dto.response;
+
+import com.example.coffeeordersystem.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class UserPointResponse {
+
+    private Long userId;
+    private BigDecimal point;
+
+    public static UserPointResponse from(User user) {
+        return UserPointResponse.builder()
+                .userId(user.getId())
+                .point(user.getPoint())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,22 @@
+package com.example.coffeeordersystem.domain.user.dto.response;
+
+import com.example.coffeeordersystem.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private BigDecimal point;
+
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .point(user.getPoint())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/user/entity/User.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.example.coffeeordersystem.domain.user.entity;
 
 import com.example.coffeeordersystem.global.common.entity.BaseEntity;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,17 +22,24 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private BigDecimal point;
 
-    public static User create() {
-        return User.builder()
-                .point(BigDecimal.ZERO)
-                .build();
-    }
-
     public void charge(BigDecimal amount) {
+        validateAmount(amount);
         this.point = this.point.add(amount);
     }
 
     public void use(BigDecimal amount) {
+        validateAmount(amount);
+
+        if (this.point.compareTo(amount) < 0) {
+            throw new ServiceException(ErrorCode.INSUFFICIENT_POINT);
+        }
+
         this.point = this.point.subtract(amount);
+    }
+
+    private void validateAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ServiceException(ErrorCode.INVALID_CHARGE_AMOUNT);
+        }
     }
 }

--- a/src/main/java/com/example/coffeeordersystem/domain/user/service/UserService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/service/UserService.java
@@ -1,0 +1,64 @@
+package com.example.coffeeordersystem.domain.user.service;
+
+import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistory;
+import com.example.coffeeordersystem.domain.pointhistory.repository.PointHistoryRepository;
+import com.example.coffeeordersystem.domain.user.dto.request.UserChargeRequest;
+import com.example.coffeeordersystem.domain.user.dto.response.UserPointResponse;
+import com.example.coffeeordersystem.domain.user.dto.response.UserResponse;
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.domain.user.repository.UserRepository;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    // 사용자 목록 조회
+    @Transactional(readOnly = true)
+    public List<UserResponse> getUsers() {
+        return userRepository.findAll().stream()
+                .map(UserResponse::from)
+                .toList();
+    }
+
+    // 사용자 단건 조회
+    @Transactional(readOnly = true)
+    public UserResponse getUser(Long userId) {
+        User user = findUser(userId);
+        return UserResponse.from(user);
+    }
+
+    // 사용자 포인트 조회
+    @Transactional(readOnly = true)
+    public UserPointResponse getUserPoint(Long userId) {
+        User user = findUser(userId);
+        return UserPointResponse.from(user);
+    }
+
+    // 포인트 충전
+    public UserPointResponse chargePoint(Long userId, UserChargeRequest request) {
+        User user = findUser(userId);
+        user.charge(request.getAmount());
+
+        pointHistoryRepository.save(PointHistory.charge(user, request.getAmount()));
+
+        return UserPointResponse.from(user);
+    }
+
+    // 사용자 조회 공통 메서드
+    // -userId로 조회 후 없으면 예외 발생
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+-- users
+INSERT INTO users (point, created_at, modified_at) VALUES (0, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (1000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (2500, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (5000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (8000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (12000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (20000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (30000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (50000, NOW(), NOW());
+INSERT INTO users (point, created_at, modified_at) VALUES (100000, NOW(), NOW());


### PR DESCRIPTION
## 📌 PR 제목
feat(user): 사용자 조회 및 포인트 충전 기능 구현

---

## ✨ 변경 사항
- User 엔티티 수정
- 사용자 목록 조회 API 구현
- 사용자 단건 조회 API 구현
- 사용자 포인트 조회 API 구현
- 포인트 충전 API 구현
- 포인트 충전 시 PointHistory 저장 로직 구현
- 테스트를 위한 data.sql 초기 데이터 추가

---

## 🔗 관련 이슈
- close #9 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [x] 사용자 정보 조회 정상 동작 확인
- [x] 예외 처리 정상 동작 확인
---

## 💡 참고 사항
- 포인트 충전 시 1원 = 1포인트 정책 적용
- 충전 금액은 0보다 커야 함 (유효성 검증 적용)
- 포인트 변경 이력은 PointHistory 테이블에 저장
- 테스트 및 API 검증을 위해 data.sql 초기 데이터 추가