### PR TITLE
feat(menu): 메뉴 조회 및 인기 메뉴 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/controller/MenuController.java
@@ -1,0 +1,39 @@
+package com.example.coffeeordersystem.domain.menu.controller;
+
+import com.example.coffeeordersystem.domain.menu.dto.response.MenuResponse;
+import com.example.coffeeordersystem.domain.menu.dto.response.PopularMenuResponse;
+import com.example.coffeeordersystem.domain.menu.service.MenuService;
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/menus")
+public class MenuController {
+
+    private final MenuService menuService;
+
+    // 메뉴 목록 조회
+    @GetMapping
+    public ApiResponse<List<MenuResponse>> getMenus() {
+        return ApiResponse.ok(menuService.getMenus());
+    }
+
+    // 메뉴 단건 조회
+    @GetMapping("/{menuId}")
+    public ApiResponse<MenuResponse> getMenu(@PathVariable Long menuId) {
+        return ApiResponse.ok(menuService.getMenu(menuId));
+    }
+
+    // 인기 메뉴 조회 (최근 7일, 상위 3개)
+    @GetMapping("/popular")
+    public ApiResponse<List<PopularMenuResponse>> getPopularMenus() {
+        return ApiResponse.ok(menuService.getPopularMenus());
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/dto/response/MenuResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/dto/response/MenuResponse.java
@@ -1,0 +1,24 @@
+package com.example.coffeeordersystem.domain.menu.dto.response;
+
+import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class MenuResponse {
+
+    private Long menuId;
+    private String name;
+    private BigDecimal price;
+
+    public static MenuResponse from(Menu menu) {
+        return MenuResponse.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/dto/response/PopularMenuResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/dto/response/PopularMenuResponse.java
@@ -1,0 +1,17 @@
+package com.example.coffeeordersystem.domain.menu.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PopularMenuResponse {
+
+    private Long menuId;
+    private String name;
+    private Long orderCount;
+
+    public PopularMenuResponse(Long menuId, String name, Long orderCount) {
+        this.menuId = menuId;
+        this.name = name;
+        this.orderCount = orderCount;
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/entity/Menu.java
@@ -22,11 +22,4 @@ public class Menu extends BaseEntity {
 
     @Column(nullable = false)
     private BigDecimal price;
-
-    public static Menu create(String name, BigDecimal price) {
-        return Menu.builder()
-                .name(name)
-                .price(price)
-                .build();
-    }
 }

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/repository/MenuRepository.java
@@ -1,7 +1,28 @@
 package com.example.coffeeordersystem.domain.menu.repository;
 
+import com.example.coffeeordersystem.domain.menu.dto.response.PopularMenuResponse;
 import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("""
+        select new com.example.coffeeordersystem.domain.menu.dto.response.PopularMenuResponse(
+            m.id,
+            m.name,
+            count(oi.id)
+        )
+        from OrderItem oi
+        join oi.menu m
+        join oi.order o
+        where o.orderedAt >= :sevenDaysAgo
+        group by m.id, m.name
+        order by count(oi.id) desc
+    """)
+    List<PopularMenuResponse> findPopularMenus(LocalDateTime sevenDaysAgo, Pageable pageable);
 }

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/service/MenuService.java
@@ -1,0 +1,50 @@
+package com.example.coffeeordersystem.domain.menu.service;
+
+
+import com.example.coffeeordersystem.domain.menu.dto.response.MenuResponse;
+import com.example.coffeeordersystem.domain.menu.dto.response.PopularMenuResponse;
+import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import com.example.coffeeordersystem.domain.menu.repository.MenuRepository;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    // 메뉴 목록 조회
+    public List<MenuResponse> getMenus() {
+        return menuRepository.findAll().stream()
+                .map(MenuResponse::from)
+                .toList();
+    }
+
+    // 메뉴 단건 조회
+    public MenuResponse getMenu(Long menuId) {
+        Menu menu = findMenu(menuId);
+        return MenuResponse.from(menu);
+    }
+
+    // 인기 메뉴 조회 (최근 7일, 상위 3개)
+    public List<PopularMenuResponse> getPopularMenus() {
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        return menuRepository.findPopularMenus(sevenDaysAgo, PageRequest.of(0, 3));
+    }
+
+    // 메뉴 조회 공통 메서드
+    // - menuId로 조회 후 없으면 예외 발생
+    private Menu findMenu(Long menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,3 +9,15 @@ INSERT INTO users (point, created_at, modified_at) VALUES (20000, NOW(), NOW());
 INSERT INTO users (point, created_at, modified_at) VALUES (30000, NOW(), NOW());
 INSERT INTO users (point, created_at, modified_at) VALUES (50000, NOW(), NOW());
 INSERT INTO users (point, created_at, modified_at) VALUES (100000, NOW(), NOW());
+
+-- menus
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('아메리카노', 4500, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('카페라떼', 5000, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('바닐라라떼', 5500, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('카푸치노', 5000, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('콜드브루', 4800, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('카라멜마끼아또', 5700, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('헤이즐넛라떼', 5500, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('아인슈페너', 6000, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('초코라떼', 5300, NOW(), NOW());
+INSERT INTO menus (name, price, created_at, modified_at) VALUES ('녹차라떼', 5200, NOW(), NOW());


### PR DESCRIPTION
## 📌 PR 제목
feat(menu): 메뉴 조회 및 인기 메뉴 조회 기능 구현

---

## ✨ 변경 사항
- Menu 엔티티 및 Repository 수정
- 메뉴 목록 조회 API 구현
- 메뉴 단건 조회 API 구현
- 인기 메뉴 조회 API 구현 (최근 7일 기준)
- 주문 데이터 기반 인기 메뉴 집계 쿼리 작성
- 조회 기준 컬럼 createdAt → orderedAt으로 변경
- 테스트를 위한 data.sql 초기 데이터 추가

---

## 🔗 관련 이슈
- close #11 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [x] 메뉴 조회 API 정상 동작 확인
- [x] 인기 메뉴 조회 API 정상 동작 확인
- [x] 예외 처리 정상 동작 확인

---

## 💡 참고 사항
- 인기 메뉴는 최근 7일 주문 데이터를 기준으로 집계
- order_items 기준으로 메뉴별 주문 횟수 count 후 상위 3개 조회
- 초기에는 createdAt 기준으로 조회하여 데이터가 조회되지 않는 문제가 있었음
- 주문 발생 시점인 orderedAt 기준으로 변경하여 문제 해결