### PR TITLE
feat(order): 주문 생성 및 조회 기능 구현 (결제 흐름 포함)

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/controller/OrderController.java
@@ -1,0 +1,39 @@
+package com.example.coffeeordersystem.domain.order.controller;
+
+import com.example.coffeeordersystem.domain.order.dto.request.OrderCreateRequest;
+import com.example.coffeeordersystem.domain.order.dto.response.OrderItemResponse;
+import com.example.coffeeordersystem.domain.order.dto.response.OrderResponse;
+import com.example.coffeeordersystem.domain.order.service.OrderItemService;
+import com.example.coffeeordersystem.domain.order.service.OrderService;
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+    private final OrderItemService orderItemService;
+
+    // 주문 생성 + 결제
+    @PostMapping
+    public ApiResponse<OrderResponse> createOrder(@RequestBody OrderCreateRequest request) {
+        return ApiResponse.created(orderService.createOrder(request));
+    }
+
+    // 주문 단건 조회
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderResponse> getOrder(@PathVariable Long orderId) {
+        return ApiResponse.ok(orderService.getOrder(orderId));
+    }
+
+    // 주문 상품 조회
+    @GetMapping("/{orderId}/items")
+    public ApiResponse<List<OrderItemResponse>> getOrderItems(@PathVariable Long orderId) {
+        return ApiResponse.ok(orderItemService.getOrderItems(orderId));
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.coffeeordersystem.domain.order.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrderCreateRequest {
+
+    private Long userId;
+    private Long menuId;
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/dto/response/OrderItemResponse.java
@@ -1,0 +1,26 @@
+package com.example.coffeeordersystem.domain.order.dto.response;
+
+import com.example.coffeeordersystem.domain.order.entity.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class OrderItemResponse {
+
+    private Long orderItemId;
+    private Long menuId;
+    private String name;
+    private BigDecimal price;
+
+    public static OrderItemResponse from(OrderItem orderItem) {
+        return OrderItemResponse.builder()
+                .orderItemId(orderItem.getId())
+                .menuId(orderItem.getMenu().getId())
+                .name(orderItem.getName())
+                .price(orderItem.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/dto/response/OrderResponse.java
@@ -1,0 +1,30 @@
+package com.example.coffeeordersystem.domain.order.dto.response;
+
+import com.example.coffeeordersystem.domain.order.entity.Order;
+import com.example.coffeeordersystem.domain.order.entity.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class OrderResponse {
+
+    private Long orderId;
+    private Long userId;
+    private BigDecimal totalPrice;
+    private OrderStatus status;
+    private LocalDateTime orderedAt;
+
+    public static OrderResponse from(Order order) {
+        return OrderResponse.builder()
+                .orderId(order.getId())
+                .userId(order.getUser().getId())
+                .totalPrice(order.getTotalPrice())
+                .status(order.getStatus())
+                .orderedAt(order.getOrderedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
@@ -31,16 +31,13 @@ public class Order extends BaseEntity {
 
     private LocalDateTime orderedAt;
 
+    // 주문 생성 = 결제 완료 상태
     public static Order create(User user, BigDecimal totalPrice) {
         return Order.builder()
                 .user(user)
                 .totalPrice(totalPrice)
-                .status(OrderStatus.WAITING)
+                .status(OrderStatus.COMPLETED)
                 .orderedAt(LocalDateTime.now())
                 .build();
-    }
-
-    public void complete() {
-        this.status = OrderStatus.COMPLETED;
     }
 }

--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/OrderStatus.java
@@ -4,9 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum OrderStatus {
-    WAITING("주문 확인"),
-    PREPARING("조리 중"),
-    COMPLETED( "조리 완료");
+    COMPLETED("주문 완료"),
+    FAILED("주문 실패");
 
     private final String description;
 

--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderItemService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderItemService.java
@@ -1,0 +1,39 @@
+package com.example.coffeeordersystem.domain.order.service;
+
+import com.example.coffeeordersystem.domain.order.dto.response.OrderItemResponse;
+import com.example.coffeeordersystem.domain.order.entity.Order;
+import com.example.coffeeordersystem.domain.order.repository.OrderItemRepository;
+import com.example.coffeeordersystem.domain.order.repository.OrderRepository;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderItemService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    // 주문 상품 조회
+    @Transactional(readOnly = true)
+    public List<OrderItemResponse> getOrderItems(Long orderId) {
+        findOrder(orderId);
+
+        return orderItemRepository.findAllByOrderId(orderId).stream()
+                .map(OrderItemResponse::from)
+                .toList();
+    }
+
+    // 주문 상품 조회 공통 메서드
+    // - orderId로 조회 후 없으면 예외 발생
+    private Order findOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
@@ -1,0 +1,94 @@
+package com.example.coffeeordersystem.domain.order.service;
+
+import com.example.coffeeordersystem.domain.menu.entity.Menu;
+import com.example.coffeeordersystem.domain.menu.repository.MenuRepository;
+import com.example.coffeeordersystem.domain.order.dto.request.OrderCreateRequest;
+import com.example.coffeeordersystem.domain.order.dto.response.OrderResponse;
+import com.example.coffeeordersystem.domain.order.entity.Order;
+import com.example.coffeeordersystem.domain.order.entity.OrderItem;
+import com.example.coffeeordersystem.domain.order.repository.OrderItemRepository;
+import com.example.coffeeordersystem.domain.order.repository.OrderRepository;
+import com.example.coffeeordersystem.domain.payment.entity.Payment;
+import com.example.coffeeordersystem.domain.payment.repository.PaymentRepository;
+import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistory;
+import com.example.coffeeordersystem.domain.pointhistory.repository.PointHistoryRepository;
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.domain.user.repository.UserRepository;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    // 주문 생성 + 결제
+    // - 메뉴 가격으로 총 금액 계산
+    // - 사용자 포인트 차감
+    // - 주문/주문상품/결제 정보를 함께 저장
+    public OrderResponse createOrder(OrderCreateRequest request) {
+        User user = findUser(request.getUserId());
+        Menu menu = findMenu(request.getMenuId());
+
+        Order order = Order.create(user, menu.getPrice());
+        Order savedOrder = orderRepository.save(order);
+
+        OrderItem orderItem = OrderItem.create(savedOrder, menu);
+        orderItemRepository.save(orderItem);
+
+        Payment payment;
+        try {
+            user.use(menu.getPrice());
+
+            pointHistoryRepository.save(PointHistory.use(user, menu.getPrice()));
+
+            payment = Payment.success(order, user, menu.getPrice());
+        } catch (ServiceException e) {
+            payment = Payment.fail(order, user, menu.getPrice());
+            paymentRepository.save(payment);
+            throw e;
+        }
+
+        paymentRepository.save(payment);
+
+        return OrderResponse.from(order);
+    }
+
+    // 주문 단건 조회
+    @Transactional(readOnly = true)
+    public OrderResponse getOrder(Long orderId) {
+        Order order = findOrder(orderId);
+        return OrderResponse.from(order);
+    }
+
+    // 사용자 조회 공통 메서드
+    // - userId로 조회 후 없으면 예외 발생
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 메뉴 조회 공통 메서드
+    // - menuId로 조회 후 없으면 예외 발생
+    private Menu findMenu(Long menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+    }
+
+    // 주문 조회 공통 메서드
+    // - orderId로 조회 후 없으면 예외 발생
+    private Order findOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat(order): 주문 생성 및 조회 기능 구현 (결제 흐름 포함)

---

## ✨ 변경 사항
- Order 엔티티 수정
- 주문 생성 API 구현
- 주문 단건 조회 API 구현
- 주문 상품 조회 API 구현
- 주문 생성 시 주문상품(OrderItem) 생성 및 저장 로직 구현
- 주문 생성 시 결제 처리 로직 구현 (포인트 차감)
- 주문 상태(OrderStatus)를 COMPLETED, FAILED로 변경

---

## 🔗 관련 이슈
- close #13 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [x] 주문 생성 및 조회 흐름 정상 동작 확인
- [x] 예외 처리 정상 동작 확인 

---

## 💡 참고 사항
- 주문 생성, 포인트 차감, 결제 저장은 하나의 트랜잭션으로 처리  
- 결제는 포인트 차감 방식으로 구현  
- 주문 생성 시 OrderItem과 Payment가 함께 생성됨 