### PR TITLE
feat(point-history): 포인트 이력 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
+++ b/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
@@ -2,7 +2,9 @@ package com.example.coffeeordersystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CoffeeOrderSystemApplication {
 

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/controller/PointHistoryController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/controller/PointHistoryController.java
@@ -1,0 +1,26 @@
+package com.example.coffeeordersystem.domain.pointhistory.controller;
+
+import com.example.coffeeordersystem.domain.pointhistory.dto.response.PointHistoryResponse;
+import com.example.coffeeordersystem.domain.pointhistory.service.PointHistoryService;
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/points")
+public class PointHistoryController {
+
+    private final PointHistoryService pointHistoryService;
+
+    // 포인트 이력 조회
+    @GetMapping("/history/{userId}")
+    public ApiResponse<List<PointHistoryResponse>> getPointHistories(@PathVariable Long userId) {
+        return ApiResponse.ok(pointHistoryService.getPointHistories(userId));
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/dto/response/PointHistoryResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/dto/response/PointHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.example.coffeeordersystem.domain.pointhistory.dto.response;
+
+import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistory;
+import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistoryStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PointHistoryResponse {
+
+    private Long historyId;
+    private BigDecimal amount;
+    private PointHistoryStatus status;
+    private LocalDateTime createdAt;
+
+    public static PointHistoryResponse from(PointHistory history) {
+        return PointHistoryResponse.builder()
+                .historyId(history.getId())
+                .amount(history.getAmount())
+                .status(history.getStatus())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/domain/pointhistory/service/PointHistoryService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/pointhistory/service/PointHistoryService.java
@@ -1,0 +1,39 @@
+package com.example.coffeeordersystem.domain.pointhistory.service;
+
+import com.example.coffeeordersystem.domain.pointhistory.dto.response.PointHistoryResponse;
+import com.example.coffeeordersystem.domain.pointhistory.repository.PointHistoryRepository;
+import com.example.coffeeordersystem.domain.user.entity.User;
+import com.example.coffeeordersystem.domain.user.repository.UserRepository;
+import com.example.coffeeordersystem.global.exception.ErrorCode;
+import com.example.coffeeordersystem.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PointHistoryService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+    private final UserRepository userRepository;
+
+    // 포인트 이력 조회
+    @Transactional(readOnly = true)
+    public List<PointHistoryResponse> getPointHistories(Long userId) {
+        findUser(userId);
+
+        return pointHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(PointHistoryResponse::from)
+                .toList();
+    }
+
+    // 포인트 이력 조회 공통 메서드
+    // - userId로 조회 후 없으면 예외 발생
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat(point-history): 포인트 이력 조회 기능 구현

---

## ✨ 변경 사항
- PointHistory 조회 API 구현
- 사용자별 포인트 이력 조회 로직 구현
- PointHistoryResponse DTO 생성 및 매핑 적용
- createdAt 기준 최신순 조회 적용
- createdAt 자동 관리를 위해 JPA Auditing 적용
- @EnableJpaAuditing 설정 추가
- BaseEntity를 통해 createdAt, modifiedAt 공통 필드 관리

---

## 🔗 관련 이슈
- close #17 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인  
- [x] API 테스트 완료  
- [x] Postman 테스트 완료  
- [x] 포인트 이력 조회 정상 동작 확인  
- [x] 예외 처리 정상 동작 확인  

---

## 💡 참고 사항
- 포인트 충전 및 사용 시 PointHistory 테이블에 이력 저장  
- 포인트 이력 상태(CHARGE, USE) 기반으로 구분  
- createdAt 기준으로 최신순 조회  