### PR TITLE
docs: README API 명세서 수정

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,19 +118,22 @@
 
 ---
 
-## 📖 API 명세서
+# 📖 API 명세서
 
 | 기능 분류 | 기능명 | API Path | Method |
 |----------|--------|----------|--------|
-| user | 사용자 조회 | `/api/users/{userId}` | GET |
+| user | 사용자 목록 조회 | `/api/users` | GET |
+| user | 사용자 단건 조회 | `/api/users/{userId}` | GET |
+| user | 사용자 포인트 조회 | `/api/users/{userId}/point` | GET |
+| user | 포인트 충전 | `/api/users/{userId}/points/charge` | POST |
 | menu | 메뉴 목록 조회 | `/api/menus` | GET |
-| point | 포인트 충전 | `/api/points/charge` | POST |
-| point | 포인트 이력 조회 | `/api/points/history/{userId}` | GET |
-| order | 주문 생성 + 결제 | `/api/orders` | POST |
-| order | 주문 조회 | `/api/orders/{orderId}` | GET |
-| order_item | 주문 상품 조회 | `/api/orders/{orderId}/items` | GET |
-| payment | 결제 조회 | `/api/payments/{orderId}` | GET |
+| menu | 메뉴 단건 조회 | `/api/menus/{menuId}` | GET |
 | menu | 인기 메뉴 조회 | `/api/menus/popular` | GET |
+| order | 주문 생성 + 결제 | `/api/orders` | POST |
+| order | 주문 단건 조회 | `/api/orders/{orderId}` | GET |
+| order_item | 주문 상품 조회 | `/api/orders/{orderId}/items` | GET |
+| payment | 결제 정보 조회 | `/api/payments/{orderId}` | GET |
+| pointhistory | 포인트 이력 조회 | `/api/points/history/{userId}` | GET |
 | external | 외부 플랫폼 전송 (Mock) | `/external/orders` | POST |
 
 ---


### PR DESCRIPTION
## 📌 PR 제목
docs: README API 명세서 수정

---

## ✨ 변경 사항
- README API 명세서 최신 구조 반영
- 사용자/포인트 API를 리소스 기반 구조로 수정
- 도메인별 API 경로(user, menu, order 등) 기준으로 재정리

---

## 🔗 관련 이슈
- close #19 

---

## 🧪 테스트
- [x] README 수정 내용 확인

---

## 💡 참고 사항
- 기존 `/points/charge` → `/users/{userId}/points/charge` 구조로 변경
- API Path를 리소스 중심 구조로 개선
- 기능 변경이 아닌 문서 수정 작업