### PR TITLE
refactor: ExceptionResponse 및 ApiResponse 구조 정리

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/global/common/dto/ApiResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/dto/ApiResponse.java
@@ -15,24 +15,16 @@ public class ApiResponse<T> {
     private final int code;
     private final T data;
 
-    public static <T> ApiResponse<T> ok() {
-        return new ApiResponse<>(true, 200, null);
-    }
-
     public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(true, 200, data);
+        return new ApiResponse<>(true, HttpStatus.OK.value(), data);
     }
 
     public static <T> ApiResponse<T> created(T data) {
-        return new ApiResponse<>(true, 201, data);
+        return new ApiResponse<>(true, HttpStatus.CREATED.value(), data);
     }
 
     public static <T> ApiResponse<T> noContent() {
-        return new ApiResponse<>(true, 204, null);
-    }
-
-    public static <T> ApiResponse<T> fail(HttpStatus status) {
-        return new ApiResponse<>(false, status.value(), null);
+        return new ApiResponse<>(true, HttpStatus.NO_CONTENT.value(), null);
     }
 
     public static <T> ApiResponse<T> fail(HttpStatus status, T data) {

--- a/src/main/java/com/example/coffeeordersystem/global/common/dto/ExceptionResponse.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/dto/ExceptionResponse.java
@@ -1,5 +1,6 @@
 package com.example.coffeeordersystem.global.common.dto;
 
+import com.example.coffeeordersystem.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,17 +10,26 @@ import java.time.LocalDateTime;
 @Builder
 public class ExceptionResponse {
 
-    private final int errorCode;
+    private final ErrorCode errorCode;
     private final String message;
     private final String path;
-    private final LocalDateTime time;
+    private final LocalDateTime timestamp;
 
-    public static ExceptionResponse from(int errorCode, String message, String path) {
+    public static ExceptionResponse from(ErrorCode errorCode, String path) {
+        return ExceptionResponse.builder()
+                .errorCode(errorCode)
+                .message(errorCode.getMessage())
+                .path(path)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ExceptionResponse from(ErrorCode errorCode, String message, String path) {
         return ExceptionResponse.builder()
                 .errorCode(errorCode)
                 .message(message)
                 .path(path)
-                .time(LocalDateTime.now())
+                .timestamp(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/GlobalExceptionHandler.java
@@ -18,17 +18,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ServiceException.class)
     public ResponseEntity<ApiResponse<ExceptionResponse>> handleServiceException(
             ServiceException exception,
-            HttpServletRequest request) {
-
-        ExceptionResponse response = ExceptionResponse.from(
-                exception.getStatus().value(),
-                exception.getErrorCode().getMessage(),
+            HttpServletRequest request
+    ) {
+        return buildErrorResponse(
+                exception.getStatus(),
+                exception.getErrorCode(),
                 request.getRequestURI()
         );
-
-        return ResponseEntity
-                .status(exception.getStatus())
-                .body(ApiResponse.fail(exception.getStatus(), response));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -41,15 +37,12 @@ public class GlobalExceptionHandler {
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("입력 값이 올바르지 않습니다.");
 
-        ExceptionResponse response = ExceptionResponse.from(
-                exception.getStatusCode().value(),
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                ErrorCode.INVALID_REQUEST,
                 errorMessage,
                 request.getRequestURI()
         );
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST, response));
     }
 
     @ExceptionHandler(Exception.class)
@@ -59,14 +52,35 @@ public class GlobalExceptionHandler {
     ) {
         log.error("Unhandled exception occurred", exception);
 
-        ExceptionResponse response = ExceptionResponse.from(
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+        return buildErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ErrorCode.INTERNAL_SERVER_ERROR,
                 request.getRequestURI()
         );
+    }
+
+    private ResponseEntity<ApiResponse<ExceptionResponse>> buildErrorResponse(
+            HttpStatus status,
+            ErrorCode errorCode,
+            String path
+    ) {
+        ExceptionResponse response = ExceptionResponse.from(errorCode, path);
 
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR, response));
+                .status(status)
+                .body(ApiResponse.fail(status, response));
+    }
+
+    private ResponseEntity<ApiResponse<ExceptionResponse>> buildErrorResponse(
+            HttpStatus status,
+            ErrorCode errorCode,
+            String message,
+            String path
+    ) {
+        ExceptionResponse response = ExceptionResponse.from(errorCode, message, path);
+
+        return ResponseEntity
+                .status(status)
+                .body(ApiResponse.fail(status, response));
     }
 }

--- a/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
+++ b/src/main/java/com/example/coffeeordersystem/global/exception/ServiceException.java
@@ -16,4 +16,8 @@ public class ServiceException extends RuntimeException {
     public HttpStatus getStatus() {
         return errorCode.getStatus();
     }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
 }


### PR DESCRIPTION
## 📌 PR 제목
refactor: ExceptionResponse 및 ApiResponse 구조 정리

---

## ✨ 변경 사항
- ExceptionResponse 구조 개선
  - ErrorCode 기반 메시지 처리로 통일
  - 기본 메시지 / 커스텀 메시지 처리 로직 분리

- GlobalExceptionHandler 리팩토링
  - 중복된 응답 생성 로직 제거
  - 공통 메서드(buildErrorResponse)로 구조 개선

- ApiResponse 구조 정리
  - 불필요한 ok() 메서드 제거
  - noContent() 메서드 추가 및 역할 명확화
  - HttpStatus 기반 코드 사용으로 매직 넘버 제거

- 예외 응답 형식 일관성 유지

---

## 🔗 관련 이슈
- close #21 

---

## 🧪 테스트
- [x] 주문 생성 API 정상 동작 확인
- [x] Postman을 통한 예외 응답 테스트
- [x] 예외 발생 시 ApiResponse 형식 유지 확인

---

## 💡 참고 사항
- ErrorCode 기반으로 메시지를 관리하여 중복을 제거하고 유지보수성을 개선함
- 필요 시 커스텀 메시지를 사용할 수 있도록 ExceptionResponse 생성 메서드 분리
- 예외 응답을 ApiResponse로 통일하여 클라이언트 응답 형식 일관성 유지