### PR TITLE
feat(external): 외부 플랫폼 주문 전송 기능 구현

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
@@ -14,15 +14,19 @@ import com.example.coffeeordersystem.domain.pointhistory.entity.PointHistory;
 import com.example.coffeeordersystem.domain.pointhistory.repository.PointHistoryRepository;
 import com.example.coffeeordersystem.domain.user.entity.User;
 import com.example.coffeeordersystem.domain.user.repository.UserRepository;
+import com.example.coffeeordersystem.external.client.ExternalOrderClient;
+import com.example.coffeeordersystem.external.dto.ExternalOrderRequest;
 import com.example.coffeeordersystem.global.exception.ErrorCode;
 import com.example.coffeeordersystem.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class OrderService {
 
     private final OrderRepository orderRepository;
@@ -31,12 +35,15 @@ public class OrderService {
     private final UserRepository userRepository;
     private final MenuRepository menuRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final ExternalOrderClient externalOrderClient;
 
     // 주문 생성 + 결제
     // - 메뉴 가격으로 총 금액 계산
     // - 사용자 포인트 차감
     // - 주문/주문상품/결제 정보를 함께 저장
     public OrderResponse createOrder(OrderCreateRequest request) {
+        log.info("주문 생성 시작 - userId={}, menuId={}", request.getUserId(), request.getMenuId());
+
         User user = findUser(request.getUserId());
         Menu menu = findMenu(request.getMenuId());
 
@@ -44,7 +51,7 @@ public class OrderService {
         Order savedOrder = orderRepository.save(order);
 
         OrderItem orderItem = OrderItem.create(savedOrder, menu);
-        orderItemRepository.save(orderItem);
+        OrderItem savedOrderItem = orderItemRepository.save(orderItem);
 
         Payment payment;
         try {
@@ -52,7 +59,7 @@ public class OrderService {
 
             pointHistoryRepository.save(PointHistory.use(user, menu.getPrice()));
 
-            payment = Payment.success(order, user, menu.getPrice());
+            payment = Payment.success(savedOrder, user, menu.getPrice());
         } catch (ServiceException e) {
             payment = Payment.fail(order, user, menu.getPrice());
             paymentRepository.save(payment);
@@ -61,7 +68,17 @@ public class OrderService {
 
         paymentRepository.save(payment);
 
-        return OrderResponse.from(order);
+        log.info("외부 플랫폼 전송 직전");
+        externalOrderClient.sendOrder(
+                new ExternalOrderRequest(
+                        user.getId(),
+                        savedOrderItem.getMenu().getId(),
+                        savedOrder.getTotalPrice()
+                )
+        );
+        log.info("외부 플랫폼 전송 직후");
+
+        return OrderResponse.from(savedOrder);
     }
 
     // 주문 단건 조회

--- a/src/main/java/com/example/coffeeordersystem/external/client/ExternalOrderClient.java
+++ b/src/main/java/com/example/coffeeordersystem/external/client/ExternalOrderClient.java
@@ -1,0 +1,32 @@
+package com.example.coffeeordersystem.external.client;
+
+import com.example.coffeeordersystem.external.dto.ExternalOrderRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalOrderClient {
+
+    private final RestTemplate restTemplate;
+
+    public void sendOrder(ExternalOrderRequest request) {
+        try {
+            log.info("ExternalOrderClient 진입");
+            restTemplate.postForEntity(
+                    "http://localhost:8080/external/orders",
+                    request,
+                    Void.class
+            );
+
+            log.info("외부 플랫폼 전송 완료 - userId={}, menuId={}, amount={}",
+                    request.getUserId(), request.getMenuId(), request.getAmount());
+        } catch (Exception e) {
+            log.error("외부 플랫폼 전송 실패", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/external/controller/ExternalMockController.java
+++ b/src/main/java/com/example/coffeeordersystem/external/controller/ExternalMockController.java
@@ -1,0 +1,23 @@
+package com.example.coffeeordersystem.external.controller;
+
+import com.example.coffeeordersystem.external.dto.ExternalOrderRequest;
+import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/external/orders")
+@Slf4j
+public class ExternalMockController {
+
+    @PostMapping
+    public ApiResponse<Void> receiveOrder(@RequestBody ExternalOrderRequest request) {
+        log.info("외부 플랫폼 주문 데이터 수신 - userId={}, menuId={}, amount={}",
+                request.getUserId(), request.getMenuId(), request.getAmount());
+
+        return ApiResponse.noContent();
+    }
+}

--- a/src/main/java/com/example/coffeeordersystem/external/dto/ExternalOrderRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/external/dto/ExternalOrderRequest.java
@@ -1,0 +1,17 @@
+package com.example.coffeeordersystem.external.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExternalOrderRequest {
+
+    private Long userId;
+    private Long menuId;
+    private BigDecimal amount;
+}

--- a/src/main/java/com/example/coffeeordersystem/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/coffeeordersystem/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.coffeeordersystem.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat(external): 외부 플랫폼 주문 전송 기능 구현

---

## ✨ 변경 사항
- 주문 생성 시 외부 플랫폼으로 주문 데이터를 전송하는 로직 추가
- ExternalOrderClient 구현
  - RestTemplate 기반 외부 API 호출 처리
- ExternalOrderRequest DTO 생성
- ExternalMockController 구현
  - 외부 플랫폼 Mock API 테스트용 엔드포인트 추가
- RestTemplateConfig 설정 추가
- OrderService에 외부 플랫폼 전송 로직 및 로그 추가

---

## 🔗 관련 이슈
- close #23 

---

## 🧪 테스트
- [x] 주문 생성 API 정상 동작 확인
- [x] Postman을 통한 외부 Mock API 직접 호출 확인
- [x] 주문 생성 시 외부 플랫폼 자동 호출 로그 확인
- [x] 외부 플랫폼 주문 데이터 수신 로그 확인

---

## 💡 참고 사항
- 현재는 외부 플랫폼 연동을 Mock API로 구현하여 테스트함
- 외부 API 호출은 동기 방식으로 처리하였으며, 추후 필요 시 비동기 구조로 확장 가능
- 주문 생성 흐름 안에서 외부 전송까지 함께 확인할 수 있도록 로그를 추가함