### PR TITLE
docs: 포인트 API 경로 변경(point → points) 내용 README에 반영

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,13 +118,13 @@
 
 ---
 
-# 📖 API 명세서
+## 📖 API 명세서
 
 | 기능 분류 | 기능명 | API Path | Method |
 |----------|--------|----------|--------|
 | user | 사용자 목록 조회 | `/api/users` | GET |
 | user | 사용자 단건 조회 | `/api/users/{userId}` | GET |
-| user | 사용자 포인트 조회 | `/api/users/{userId}/point` | GET |
+| user | 사용자 포인트 조회 | `/api/users/{userId}/points` | GET |
 | user | 포인트 충전 | `/api/users/{userId}/points/charge` | POST |
 | menu | 메뉴 목록 조회 | `/api/menus` | GET |
 | menu | 메뉴 단건 조회 | `/api/menus/{menuId}` | GET |
@@ -134,7 +134,6 @@
 | order_item | 주문 상품 조회 | `/api/orders/{orderId}/items` | GET |
 | payment | 결제 정보 조회 | `/api/payments/{orderId}` | GET |
 | pointhistory | 포인트 이력 조회 | `/api/points/history/{userId}` | GET |
-| external | 외부 플랫폼 전송 (Mock) | `/external/orders` | POST |
 
 ---
 


### PR DESCRIPTION
## 📌 PR 제목
docs: 포인트 API 경로 변경(point → points) 내용 README에 반영

---

## ✨ 변경 사항
- 포인트 조회 API 경로 변경(`/point` → `/points`) 내용을 README에 반영
- API 명세서와 실제 구현 간 불일치 해소
- external API(`/external/orders`) 명세 제거

---

## 🔗 관련 이슈
- close #27 

---

## 🧪 테스트
- [x] README 내용 변경 확인
- [x] API 명세서와 실제 구현 일치 여부 확인

---

## 💡 참고 사항
- 포인트 API는 RESTful 설계 원칙에 따라 복수형(`points`)으로 통일됨
- external API는 클라이언트 호출 API가 아닌 내부 로직에서 사용되는 API이므로 명세서에서 제외