### PR TITLE
feat: 외부 API 호출 비동기 처리 적용 (@Async)

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
+++ b/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
@@ -3,8 +3,10 @@ package com.example.coffeeordersystem;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
+@EnableAsync
 @SpringBootApplication
 public class CoffeeOrderSystemApplication {
 

--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
@@ -16,6 +16,7 @@ import com.example.coffeeordersystem.domain.user.entity.User;
 import com.example.coffeeordersystem.domain.user.repository.UserRepository;
 import com.example.coffeeordersystem.external.client.ExternalOrderClient;
 import com.example.coffeeordersystem.external.dto.ExternalOrderRequest;
+import com.example.coffeeordersystem.external.service.ExternalOrderAsyncService;
 import com.example.coffeeordersystem.global.exception.ErrorCode;
 import com.example.coffeeordersystem.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class OrderService {
     private final MenuRepository menuRepository;
     private final PointHistoryRepository pointHistoryRepository;
     private final ExternalOrderClient externalOrderClient;
+    private final ExternalOrderAsyncService externalOrderAsyncService;
 
     // 주문 생성 + 결제
     // - 메뉴 가격으로 총 금액 계산
@@ -56,9 +58,7 @@ public class OrderService {
         Payment payment;
         try {
             user.use(menu.getPrice());
-
             pointHistoryRepository.save(PointHistory.use(user, menu.getPrice()));
-
             payment = Payment.success(savedOrder, user, menu.getPrice());
         } catch (ServiceException e) {
             payment = Payment.fail(order, user, menu.getPrice());
@@ -68,8 +68,8 @@ public class OrderService {
 
         paymentRepository.save(payment);
 
-        log.info("외부 플랫폼 전송 직전");
-        externalOrderClient.sendOrder(
+        log.info("외부 플랫폼 비동기 전송 요청");
+        externalOrderAsyncService.sendOrderAsync(
                 new ExternalOrderRequest(
                         user.getId(),
                         savedOrderItem.getMenu().getId(),

--- a/src/main/java/com/example/coffeeordersystem/external/service/ExternalOrderAsyncService.java
+++ b/src/main/java/com/example/coffeeordersystem/external/service/ExternalOrderAsyncService.java
@@ -1,0 +1,29 @@
+package com.example.coffeeordersystem.external.service;
+
+import com.example.coffeeordersystem.external.client.ExternalOrderClient;
+import com.example.coffeeordersystem.external.dto.ExternalOrderRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalOrderAsyncService {
+
+    private final ExternalOrderClient externalOrderClient;
+
+    @Async
+    public void sendOrderAsync(ExternalOrderRequest request) {
+        try {
+            log.info("비동기 외부 플랫폼 전송 시작 - thread={}", Thread.currentThread().getName());
+
+            externalOrderClient.sendOrder(request);
+
+            log.info("비동기 외부 플랫폼 전송 완료");
+        } catch (Exception e) {
+            log.error("비동기 외부 플랫폼 전송 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 외부 API 호출 비동기 처리 적용 (@Async)

---

## ✨ 변경 사항
- 외부 API 호출을 동기 방식에서 비동기(@Async) 방식으로 변경
- ExternalOrderAsyncService 클래스 추가
- 주문 서비스에서 외부 전송 로직을 비동기 호출로 변경

---

## 🔗 관련 이슈
- close #31 

---

## 🧪 테스트
- [x] 주문 API 정상 동작 확인
- [x] 외부 API 비동기 호출 로그 확인
- [x] Postman 테스트 완료

---

## 💡 참고 사항
- 외부 API 호출을 비동기 처리하여 주문 API 응답 속도 개선
- 현재는 @Async 기반 비동기 처리 적용
- 이후 이벤트 기반(@TransactionalEventListener) 구조로 리팩토링 예정