### PR TITLE
feat: 포인트 차감 동시성 제어를 위한 비관적 락 적용

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
@@ -46,7 +46,7 @@ public class OrderService {
     public OrderResponse createOrder(OrderCreateRequest request) {
         log.info("주문 생성 시작 - userId={}, menuId={}", request.getUserId(), request.getMenuId());
 
-        User user = findUser(request.getUserId());
+        User user = findUserWithLock(request.getUserId());
         Menu menu = findMenu(request.getMenuId());
 
         Order order = Order.create(user, menu.getPrice());
@@ -92,6 +92,13 @@ public class OrderService {
     // - userId로 조회 후 없으면 예외 발생
     private User findUser(Long userId) {
         return userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 포인트 차감용 사용자 조회
+    // - 비관적 락 적용
+    private User findUserWithLock(Long userId) {
+        return userRepository.findByIdWithPessimisticLock(userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/example/coffeeordersystem/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/repository/UserRepository.java
@@ -1,7 +1,17 @@
 package com.example.coffeeordersystem.domain.user.repository;
 
 import com.example.coffeeordersystem.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :userId")
+    Optional<User> findByIdWithPessimisticLock(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 📌 PR 제목
feat: 포인트 차감 동시성 제어를 위한 비관적 락 적용

---

## ✨ 변경 사항
- 사용자 포인트 차감 시 동시성 문제 해결을 위해 비관적 락 적용
- UserRepository에 PESSIMISTIC_WRITE 기반 조회 메서드 추가
- 기존 사용자 조회 로직을 락 기반 조회로 변경
- 포인트 차감 시 동시 접근 제어 로직 적용

---

## 🔗 관련 이슈
- close #37 

---

## 🧪 테스트
- [x] 애플리케이션 실행 확인
- [ ] 동시성 테스트 코드 검증 (추가 예정)

---

## 💡 참고 사항
- 포인트 차감 시 발생할 수 있는 Lost Update 문제 해결
- SELECT ... FOR UPDATE 기반으로 동시성 제어 수행
- 데이터 정합성이 중요한 로직에 대해 비관적 락 적용