### PR TITLE
perf: 인기 메뉴 조회 성능 개선을 위한 Order.created_at 인덱스 추가

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/entity/Order.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @Builder
-@Table(name = "orders")
+@Table(name = "orders", indexes = {@Index(name = "idx_order_created_at", columnList = "created_at")})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Order extends BaseEntity {

--- a/src/main/java/com/example/coffeeordersystem/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/coffeeordersystem/global/common/entity/BaseEntity.java
@@ -15,8 +15,10 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
+
     @LastModifiedDate
+    @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
 }


### PR DESCRIPTION
## 📌 PR 제목
perf: 인기 메뉴 조회 성능 개선을 위한 Order.created_at 인덱스 추가

---

## ✨ 변경 사항
- BaseEntity createdAt, modifiedAt 컬럼명 명시
- Order.created_at 인덱스 추가
- 인기 메뉴 조회 성능 개선 작업

---

## 🔗 관련 이슈
- close #41 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] 애플리케이션 실행 확인
- [x] 인기 메뉴 조회 API 정상 동작 확인
- [x] EXPLAIN을 통한 인덱스 사용 여부 확인

---

## 💡 참고 사항
- createdAt → created_at, modifiedAt → modified_at 컬럼명 명시
- 인기 메뉴 조회 시 최근 7일 데이터 조회 성능 개선 목적
- 인덱스를 통해 range scan 유도