### PR TITLE
fix: OrderCreateRequest builder 제거 및 생성자 기반으로 변경

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
@@ -1,10 +1,13 @@
 package com.example.coffeeordersystem.domain.order.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OrderCreateRequest {
 
     private Long userId;

--- a/src/test/java/com/example/coffeeordersystem/domain/order/service/OrderServiceConcurrencyTest.java
+++ b/src/test/java/com/example/coffeeordersystem/domain/order/service/OrderServiceConcurrencyTest.java
@@ -77,10 +77,7 @@ class OrderServiceConcurrencyTest {
                 try {
                     startLatch.await(); // 모든 스레드 동시에 실행
 
-                    OrderCreateRequest request = OrderCreateRequest.builder()
-                            .userId(user.getId())
-                            .menuId(menu.getId())
-                            .build();
+                    OrderCreateRequest request = new OrderCreateRequest(user.getId(), menu.getId());
 
                     orderService.createOrder(request);
                     successCount.incrementAndGet();


### PR DESCRIPTION
## 📌 PR 제목
fix: OrderCreateRequest builder 제거 및 생성자 기반으로 변경

---

## ✨ 변경 사항
- OrderCreateRequest에서 @Builder 제거
- @NoArgsConstructor, @AllArgsConstructor 추가
- 생성자 기반 객체 생성 방식으로 변경
- 테스트 코드 builder → 생성자 방식으로 수정

---

## 🔗 관련 이슈
- close #43 

---

## 🧪 테스트
- [x] 주문 생성 API 정상 동작 확인
- [x] @RequestBody 역직렬화 정상 동작 확인
- [x] 테스트 코드 정상 실행 확인

---

## 💡 참고 사항
- builder만 존재할 경우 Jackson이 객체를 생성할 수 없어 에러 발생
- 요청 DTO는 기본 생성자 기반 구조로 설계하는 것이 안정적
- 요청 DTO와 응답 DTO의 생성 방식은 다르게 가져가는 것이 좋음 (Request: 생성자, Response: Builder)