### PR TITLE
perf: 인기 메뉴 조회 캐싱 적용 및 캐시 무효화 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
+++ b/src/main/java/com/example/coffeeordersystem/CoffeeOrderSystemApplication.java
@@ -2,11 +2,13 @@ package com.example.coffeeordersystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @EnableAsync
+@EnableCaching
 @SpringBootApplication
 public class CoffeeOrderSystemApplication {
 

--- a/src/main/java/com/example/coffeeordersystem/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/menu/service/MenuService.java
@@ -7,6 +7,8 @@ import com.example.coffeeordersystem.domain.menu.repository.MenuRepository;
 import com.example.coffeeordersystem.global.exception.ErrorCode;
 import com.example.coffeeordersystem.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class MenuService {
 
     private final MenuRepository menuRepository;
@@ -35,7 +38,9 @@ public class MenuService {
     }
 
     // 인기 메뉴 조회 (최근 7일, 상위 3개)
+    @Cacheable(value = "popularMenus")
     public List<PopularMenuResponse> getPopularMenus() {
+        log.info("인기 메뉴 DB 조회 실행");
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
         return menuRepository.findPopularMenus(sevenDaysAgo, PageRequest.of(0, 3));
     }

--- a/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/service/OrderService.java
@@ -19,6 +19,7 @@ import com.example.coffeeordersystem.global.exception.ErrorCode;
 import com.example.coffeeordersystem.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,7 @@ public class OrderService {
     // - 포인트 차감 및 포인트 이력 저장
     // - 결제 성공 / 실패 정보 저장
     // - 외부 플랫폼 이벤트 발행 (비동기)
+    @CacheEvict(value = "popularMenus", allEntries = true)
     public OrderResponse createOrder(OrderCreateRequest request) {
         log.info("주문 생성 시작 - userId={}, menuId={}", request.getUserId(), request.getMenuId());
 

--- a/src/main/java/com/example/coffeeordersystem/global/config/CacheConfig.java
+++ b/src/main/java/com/example/coffeeordersystem/global/config/CacheConfig.java
@@ -1,0 +1,36 @@
+package com.example.coffeeordersystem.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                GenericJacksonJsonRedisSerializer.create(builder -> {})
+                        )
+                );
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(configuration)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
perf: 인기 메뉴 조회 캐싱 적용 및 캐시 무효화 처리

---

## ✨ 변경 사항
- 인기 메뉴 조회 캐싱 적용 (@Cacheable)
- 주문 생성 시 캐시 무효화 처리 (@CacheEvict)
- Redis CacheManager 설정 추가
- 캐싱 동작 검증 (Redis 키 및 로그 기반)

---

## 🔗 관련 이슈
- close #49 

---

## 🧪 테스트
- [x] Redis 키 생성 확인 (`popularMenus::SimpleKey []`)
- [x] 동일 요청 시 DB 조회 로그 미출력 확인 (캐시 조회)
- [x] 주문 생성 후 DB 조회 로그 재출력 확인 (캐시 무효화)

---

## 💡 참고 사항
- 인덱스 적용 이후 추가적인 성능 개선을 위해 캐싱을 도입했습니다.
- 반복 조회되는 인기 메뉴 데이터를 캐싱하여 DB 접근을 줄였습니다.
- 캐싱 테스트코드는 제외하고 Redis 및 로그 기반으로 동작을 검증했습니다.