### PR TITLE
feat: 요청 DTO validation(@Valid) 적용

### DIFF
--- a/src/main/java/com/example/coffeeordersystem/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/controller/OrderController.java
@@ -6,6 +6,7 @@ import com.example.coffeeordersystem.domain.order.dto.response.OrderResponse;
 import com.example.coffeeordersystem.domain.order.service.OrderItemService;
 import com.example.coffeeordersystem.domain.order.service.OrderService;
 import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,7 +22,7 @@ public class OrderController {
 
     // 주문 생성 + 결제
     @PostMapping
-    public ApiResponse<OrderResponse> createOrder(@RequestBody OrderCreateRequest request) {
+    public ApiResponse<OrderResponse> createOrder(@RequestBody @Valid OrderCreateRequest request) {
         return ApiResponse.created(orderService.createOrder(request));
     }
 

--- a/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/order/dto/request/OrderCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.coffeeordersystem.domain.order.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OrderCreateRequest {
 
+    @NotNull(message = "userId는 필수입니다.")
     private Long userId;
+
+    @NotNull(message = "menuId는 필수입니다.")
     private Long menuId;
 }

--- a/src/main/java/com/example/coffeeordersystem/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.coffeeordersystem.domain.user.dto.response.UserPointResponse;
 import com.example.coffeeordersystem.domain.user.dto.response.UserResponse;
 import com.example.coffeeordersystem.domain.user.service.UserService;
 import com.example.coffeeordersystem.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,7 +40,7 @@ public class UserController {
     @PostMapping("/{userId}/points/charge")
     public ApiResponse<UserPointResponse> chargePoint(
             @PathVariable Long userId,
-            @RequestBody UserChargeRequest request
+            @RequestBody @Valid UserChargeRequest request
     ) {
         return ApiResponse.ok(userService.chargePoint(userId, request));
     }

--- a/src/main/java/com/example/coffeeordersystem/domain/user/dto/request/UserChargeRequest.java
+++ b/src/main/java/com/example/coffeeordersystem/domain/user/dto/request/UserChargeRequest.java
@@ -1,5 +1,7 @@
 package com.example.coffeeordersystem.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +13,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class UserChargeRequest {
 
+    @NotNull(message = "충전 금액은 필수입니다.")
+    @Positive(message = "충전 금액은 0보다 커야 합니다.")
     private BigDecimal amount;
 }


### PR DESCRIPTION
## 📌 PR 제목
feat: 요청 DTO validation(@Valid) 적용

---

## ✨ 변경 사항
- OrderCreateRequest에 @NotNull 적용
- UserChargeRequest에 @NotNull, @Positive 적용
- Controller에 @Valid 추가
- 입력값 검증 실패 시 400 에러 반환

---

## 🔗 관련 이슈
- close #69 

---

## 🧪 테스트
- [x] 정상 요청 시 정상 응답 확인
- [x] 필수값 누락 시 400 에러 발생 확인
- [x] 잘못된 값(음수 등) 입력 시 검증 실패 확인

---

## 💡 참고 사항
- Bean Validation을 활용하여 입력값 검증 처리
- @Valid를 통해 컨트롤러에서 자동 검증 수행
- 검증 실패 시 GlobalExceptionHandler에서 공통 응답 형식으로 처리